### PR TITLE
Include missing change from master (#310)

### DIFF
--- a/README-license-annotations.md
+++ b/README-license-annotations.md
@@ -10,6 +10,7 @@ Based on your deployment type, use the following annotations:
 - [IBM ODM on Kubernetes (Production)](#ibm-odm-on-kubernetes-production)
 - [IBM ODM on Kubernetes (Non-Production)](#ibm-odm-on-kubernetes-non-production)
 
+The annotations below are defined for ODM version 8.11.0, but you can also use them for ODM v8.10.5.1 by replacing **productVersion** value with "8.10.5.1".
 
 ## Guidance
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This documentations applies to Operational Decision Management Standard V8.11.x 
 
 # References
 - [DevWorks article : Deploy an IBM Operational Decision Manager topology with Docker Compose ](https://www.ibm.com/developerworks/library/mw-1612-grateau-trs/1612-grateau.html)
-- [IBM Operational Decision Manager Developer Center](https://developer.ibm.com/odm/)
+- [IBM Business Automation Community](https://community.ibm.com/community/user/automation/communities/community-home?CommunityKey=c0005a22-520b-4181-bfad-feffd8bdc022)
 
 # Issues and contributions
 


### PR DESCRIPTION
* Deliver 8.11 Release (#290)

* enable FIPS

* https://github.ibm.com/dba/icp4a-odm/issues/576

* https://github.ibm.com/dba/icp4a-odm/issues/567

* https://github.ibm.com/dba/icp4a-odm/issues/580

* https://github.ibm.com/dba/icp4a-odm/issues/575

* https://github.ibm.com/dba/icp4a-odm/issues/575

* https://github.ibm.com/dba/icp4a-odm/issues/575

* https://github.ibm.com/dba/icp4a-odm/issues/575

* https://github.ibm.com/dba/icp4a-odm/issues/576

* enable FIPS by default on Docker image

* move FIPS enable on amd64 base image only

* Update or add context-param in web.xml runtime

* Allow to specify a docker builder image. (#275)

* Allow to specify a docker builder image.

* Remove volume section

* Use dockerbuilder env variable

* Improve build by adding the capability to override the settings.xml for the maven part

* Try to fix bamboo build

* Update setting.xml

* remove decision-center-client-api.zip build

* Add authentication customization in web.xml using ENABLE_TLS_AUTH env var

* update IAM tests

* https://github.ibm.com/dba/icp4a-odm/issues/549

* update IAM tests

* removing teamserver from md doc

* referencing teamserver not needed anymore

* removing teamserver from md doc

* https://github.ibm.com/dba/icp4a-odm/issues/511

* Move to github action (#279)

* pb with rm swidtag on OKD

* Move to new release.

* Renamed workflow

* no message

* First try

* Get docker-compose

* Env variables are not in a list, it's a YAML dict

* Try sudo

* Try the full chain

* Don't know what the (failing) egrep is about

* Try to download ODM dist from right place

* Debug

* Try to get right value from secret

* Try sth else

* 8.10.5.1 seems to be unavailable

* Debug

* Removed debug

* Update the VM

* Try to get meaningful error messages

* Try another way to build

Co-authored-by: mathias-mouly <mathias.mouly@fr.ibm.com>
Co-authored-by: Pierre-Yves Lochou <pylochou@fr.ibm.com>

* Rename settings file

* Refresh liberty + Upgrade to Postgresql13

* Move to the latest postgresql version.

No that the 42.2.19 version include fixes in sasl protocol.

* restore teamserver-dbdump war copy

* https://github.ibm.com/dba/icp4a-odm/issues/612

* Change VTT to pull images

* Change VTT To pull images

* Refresh liberty version to 21.0.0.9

* Update build.sh

* take into account server config in demo mode with contextroot DBACLD-11443

* Implement support of context root in case of db sample.

* Update description in Dockerhub (#280)

* keycloak material

* Fix issue tracker link

* Fix download of the postgresql driver

* Fix download of the postgresql driver.

* Typo to retrieve the jar files.

* move to client_credentials grant_type

* Add -Xshareclasses:none jvm option in keytool commands (#281)

* adapt server update in demo mode for Zen

* put RuleDesigner files under assets

* forgor RD provider template

* typo

* missing context root replace

* replace URL internal service token URL endpoint by external URL

* typo

* Move the actions build to 8.10.5.1 Release (#285)

* to trigger action

* Update to 8.10.5.1 release

* disable ALL_AUTHENTICATED_USER for rtsUser

* Prepare next release. License update.

* Add doc for metering annotation (#284)

* Add new md file to document metering annotations

* Add example

* Update README-license-annotations.md

I added a few mentions to "custom ODM containers"

* Fix example to use res

* Fix image name

* Update after review

Co-authored-by: avi44522 <antviaud@gmail.com>

* Fix productVersion value (#286)

* Update ODM version

* move UMS server

* https://jsw.ibm.com/browse/DBACLD-16340

* update eclipse version

* Update to raw version

* Add env var USERS_PASSWORD to configure the password used for the default users in standalone image

* Fix sed

* remove teamserver URL

* change the ODM doc link

* update free image welcome page

* new www.ibm.com & doc cert

* Try to fix KPI Issue

* Fix build

* Fix prod build

* Fix last kpi

* Update doc links for 8.11.0.0

* Update build-and-test.yml

Co-authored-by: mathias-mouly <mathias.mouly@fr.ibm.com>
Co-authored-by: Julie Garrone <julie.garrone@fr.ibm.com>
Co-authored-by: Julie Garrone <47252804+julie-garrone@users.noreply.github.com>
Co-authored-by: Pierre-Yves Lochou <pylochou@fr.ibm.com>
Co-authored-by: avi44522 <antviaud@gmail.com>
Co-authored-by: julie-garrone <julie.garrone@fr.ibm.om>

* Bump httpclient from 4.5.2 to 4.5.13 in /standalone/samples/loan-server (#270)

Bumps httpclient from 4.5.2 to 4.5.13.

---
updated-dependencies:
- dependency-name: org.apache.httpcomponents:httpclient
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* https://jsw.ibm.com/browse/DBACLD-31678

make server definition editable

* https://jsw.ibm.com/browse/DBACLD-31678

update server password

* Update README-license-annotations.md (#292)

Added a line to indicate that the annotations are also valid for ODM 8.10.5.1

* Update README.md (#291)

Replaced link to old Developer Center by one to the BA community - Decision Management topic.

* Simplify merge

Co-authored-by: mathias-mouly <mathias.mouly@fr.ibm.com>
Co-authored-by: Julie Garrone <julie.garrone@fr.ibm.com>
Co-authored-by: Julie Garrone <47252804+julie-garrone@users.noreply.github.com>
Co-authored-by: Pierre-Yves Lochou <pylochou@fr.ibm.com>
Co-authored-by: avi44522 <antviaud@gmail.com>
Co-authored-by: julie-garrone <julie.garrone@fr.ibm.om>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>