### PR TITLE
Fix for Dockerfile smell DL3048

### DIFF
--- a/databases/postgresql/Dockerfile
+++ b/databases/postgresql/Dockerfile
@@ -30,16 +30,14 @@ LABEL name="DBServer"
 LABEL io.k8s.display-name="DBServer"
 LABEL description="The Database server stores decision service artifacts."
 
-
 LABEL summary="Database server to store decisions artifacts."
 LABEL io.k8s.description="Database server to store decisions artifacts."
 
 LABEL vendor="IBM"
 LABEL version=${ODMVERSION}
-LABEL ProductVersion=${ODMVERSION}
-LABEL ProductID="IBM Operational Decision Manager for production"
+LABEL product-version=${ODMVERSION}
+LABEL product-id="IBM Operational Decision Manager for production"
 LABEL io.openshift.tags="odm,dba,dbamc"
-
 
 COPY --from=builder --chown=999:999 /upload /upload
 


### PR DESCRIPTION
Hi!
The Dockerfile placed at "databases/postgresql/Dockerfile" contains the best practice violation [DL3048](https://github.com/hadolint/hadolint/wiki/DL3048) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3048 occurs when the pattern used for the label keys does not match the format recommended by official guidelines.
In this pull request, we propose a fix for that smell generated by our fixing tool. We verified that the patch is correct before opening the pull request.
To fix this smell, specifically, the label keys are refactored to match the correct format.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance.