### PR TITLE
Fix CVE-2022-41946 (DBACLD-101707)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -34,4 +34,4 @@ jobs:
           status: ${{ job.status }}
           # notify_when: 'failure'
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ mkdir ${HOME}/.cache
 
 echo "ODM distribution: Starting download..."
 ODM_ZIP_URL=${ODM_URL}/${ODM_VERSION}/icp-docker-compose-build-images-${ODM_VERSION}.zip
-curl ${ODM_ZIP_URL} -u "${ARTIFACTORY_USER}:${ARTIFACTORY_PASSWORD}" -o ${HOME}/.cache/${ODM_FILE_NAME}
+curl -k ${ODM_ZIP_URL} -u "${ARTIFACTORY_USER}:${ARTIFACTORY_PASSWORD}" -o ${HOME}/.cache/${ODM_FILE_NAME}
 echo "ODM distribution: download finished..."
 
 echo "unzip odm distribution..."

--- a/common/script/installPostgres.sh
+++ b/common/script/installPostgres.sh
@@ -3,5 +3,5 @@
 # Install the driver for PostgreSQL
 echo "Install the driver for postgreSQL"
 cd /tmp
-curl -O -k -s https://jdbc.postgresql.org/download/postgresql-42.4.1.jar
+curl -O -k -s https://jdbc.postgresql.org/download/postgresql-42.4.3.jar
 mv postgres* /config/resources


### PR DESCRIPTION
cpe:2.3:a:postgresql:postgresql_jdbc_driver:* From (including) 42.4.0 Up to (excluding) 42.4.3
https://jsw.ibm.com/browse/DBACLD-101707