### PR TITLE
DBACLD-138432: Refresh ODM on docker compose script with new keywords…

### DIFF
--- a/databases/derby/Dockerfile
+++ b/databases/derby/Dockerfile
@@ -48,4 +48,5 @@ RUN \
 	echo "killasgroup=true" >> /etc/supervisor.conf
 VOLUME ["/dbs"]
 EXPOSE 1527
+HEALTHCHECK NONE
 CMD supervisord -c /etc/supervisor.conf

--- a/databases/postgresql/Dockerfile
+++ b/databases/postgresql/Dockerfile
@@ -56,6 +56,7 @@ COPY --from=builder --chown=999:999 /tmp/restore.sh  /docker-entrypoint-initdb.d
 COPY --from=builder  --chown=999:0 /licenses /licenses
 COPY --from=builder  --chown=999:0 /licenses /licenses
 USER 999
+HEALTHCHECK NONE
 ENTRYPOINT ["/usr/local/bin/rundb.sh"]
 
 CMD ["postgres"]

--- a/decisioncenter/Dockerfile
+++ b/decisioncenter/Dockerfile
@@ -111,3 +111,4 @@ COPY --from=builder --chown=1001:0 $SCRIPT $SCRIPT
 COPY --from=builder  --chown=1001:0 /licenses /licenses
 USER 1001
 EXPOSE 9060 9453
+HEALTHCHECK NONE

--- a/decisionserver/decisionrunner/Dockerfile
+++ b/decisionserver/decisionrunner/Dockerfile
@@ -92,3 +92,4 @@ COPY --from=builder  --chown=1001:0 /licenses /licenses
 COPY --from=oidc-liberty-builder /opt/ibm/version.txt /opt/ibm/version.txt
 USER 1001
 EXPOSE 9080 9443
+HEALTHCHECK NONE

--- a/decisionserver/decisionserverconsole/Dockerfile
+++ b/decisionserver/decisionserverconsole/Dockerfile
@@ -95,3 +95,4 @@ COPY --from=builder  --chown=1001:0 /licenses /licenses
 COPY --from=oidc-liberty-builder /opt/ibm/version.txt /opt/ibm/version.txt
 USER 1001
 EXPOSE 9080 9443 1883
+HEALTHCHECK NONE

--- a/decisionserver/decisionserverruntime/Dockerfile
+++ b/decisionserver/decisionserverruntime/Dockerfile
@@ -109,3 +109,4 @@ COPY --from=builder  --chown=1001:0 /licenses /licenses
 COPY --from=oidc-liberty-builder /opt/ibm/version.txt /opt/ibm/version.txt
 USER 1001
 EXPOSE 9080 9443
+HEALTHCHECK NONE

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,12 @@ services:
         - FROMPOSTGRES=$FROMPOSTGRES
         - POSTGRESUID=$POSTGRESUID
     user: "$POSTGRESUID:$POSTGRESUID"
+    restart: always
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U odmusr -d odmdb"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     ports:
     - 5432:5432
     environment:
@@ -39,10 +45,15 @@ services:
         - FROMDOCKERBUILD=$FROMDOCKERBUILD
         - FROMLIBERTYBUILD=$FROMLIBERTY
         - PACKAGELIST=$PACKAGELIST
-    links:
-    - dbserver
     depends_on:
     - dbserver
+    restart: always
+    healthcheck:
+      test: ["CMD", "curl", "-k", "-f", "https://localhost:9443/res/login.jsf"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 50s
     ports:
     - 9080:9080
     - 1883:1883
@@ -61,12 +72,18 @@ services:
         - FROMDOCKERBUILD=$FROMDOCKERBUILD
         - FROMLIBERTYBUILD=$FROMLIBERTY
         - PACKAGELIST=$PACKAGELIST
-    links:
-    - dbserver
-    - odm-decisionserverconsole
     depends_on:
-    - dbserver
-    - odm-decisionserverconsole
+      dbserver:
+        condition: service_healthy
+      odm-decisionserverconsole:
+        condition: service_healthy
+    restart: always
+    healthcheck:
+      test: ["CMD", "curl", "-k", "-f", "https://localhost:9443/DecisionRunner"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 50s
     ports:
     - 9070:9080
     - 9743:9443
@@ -86,12 +103,18 @@ services:
         - PACKAGELIST=$PACKAGELIST
     environment:
       - DECISIONSERVERCONSOLE_NAME=odm-decisionserverconsole
-    links:
-    - dbserver
-    - odm-decisionserverconsole
     depends_on:
-    - dbserver
-    - odm-decisionserverconsole
+      dbserver:
+        condition: service_healthy
+      odm-decisionserverconsole:
+        condition: service_healthy
+    restart: always
+    healthcheck:
+      test: ["CMD", "curl", "-k", "-f", "https://localhost:9443/DecisionService"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 50s
     ports:
     - 9090:9080
     - 9943:9443
@@ -110,10 +133,15 @@ services:
         - FROMDOCKERBUILD=$FROMDOCKERBUILD
         - FROMLIBERTYBUILD=$FROMLIBERTY
         - PACKAGELIST=$PACKAGELIST
-    links:
-    - dbserver
     depends_on:
     - dbserver
+    restart: always
+    healthcheck:
+      test: ["CMD", "curl", "-k", "-f", "https://localhost:9453/decisioncenter/healthCheck?dontCheckDecisionModel=true"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 50s
     environment:
     - JVM_ARGS="-Xmx14000m"
     ports:

--- a/standalone-tomcat/Dockerfile
+++ b/standalone-tomcat/Dockerfile
@@ -73,5 +73,6 @@ RUN $SCRIPT/loadFeatures.sh $SCRIPT
 
 VOLUME ["/usr/local/tomcat/dbdata/"]
 EXPOSE 8080
+HEALTHCHECK NONE
 
 CMD ["/usr/local/tomcat/script/runserver.sh"]

--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -143,6 +143,7 @@ COPY --from=builder --chown=1001:0 ${SCRIPT} ${SCRIPT}
 # VOLUME ["/config/dbdata/"]
 USER 1001
 EXPOSE 9060 9453
+HEALTHCHECK NONE
 
 ENTRYPOINT ["/script/runserver.sh"]
 CMD ["/script/runserver.sh"]


### PR DESCRIPTION
DBACLD-138432: Refresh ODM on docker compose script with new keywords (restart, healthcheck) and remove deprecated keyword 'links' (which also causes errors when using Podman and is not required in our context)