### PR TITLE
error setting up PKJWT when customization.trustedCertificateList is not set

### DIFF
--- a/common/script/configureTlsSecurity.sh
+++ b/common/script/configureTlsSecurity.sh
@@ -124,10 +124,10 @@ fi
 
 # This part allow to import a list of PEM certificate in the JVM
  echo "Importing trusted certificates $dir"
+TRUSTSTORE=/config/security/truststore.jks
 CERTDIR="/config/security/trusted-cert-volume/"
 if [ -d $CERTDIR ]; then
     cd $CERTDIR
-    TRUSTSTORE=/config/security/truststore.jks
     i=0
     for file in $(find . -name "*.crt")
     do


### PR DESCRIPTION
This change fixes a problem happening when `customization.privateCertificateList` is set and `customization.trustedCertificateList` is not

If `customization.trustedCertificateList` is not set, then the block of code below is not executed:
https://github.com/DecisionsDev/odm-ondocker/blob/vnext-release/common/script/configureTlsSecurity.sh#L129-L140
and as a consequence, `$TRUSTSTORE` is not defined,

which causes an error at the line below when trying to import the PKJWT public key into the truststore: 
https://github.com/DecisionsDev/odm-ondocker/blob/vnext-release/common/script/configureTlsSecurity.sh#L157C113-L157C134