### PR TITLE
establish trust by using the default certificates

### DIFF
--- a/common/config/tlsSecurity.xml
+++ b/common/config/tlsSecurity.xml
@@ -1,6 +1,6 @@
 <server>
   <sslDefault sslRef="odmDefaultSSLConfig" />
-  <ssl id="odmDefaultSSLConfig" verifyHostname="false" keyStoreRef="odmDefaultKeyStore" trustStoreRef="odmDefaultTrustStore" sslProtocol="TLSv1.2,TLSv1.3" enabledCiphers="ENABLED_CIPHERS" />
+  <ssl id="odmDefaultSSLConfig" verifyHostname="false" keyStoreRef="odmDefaultKeyStore" trustStoreRef="odmDefaultTrustStore" sslProtocol="TLSv1.2,TLSv1.3" enabledCiphers="ENABLED_CIPHERS" trustDefaultCerts="true" />
   <keyStore id="odmDefaultKeyStore" location="/config/security/keystore.p12" password="__KEYSTORE_PASSWORD__" type="PKCS12" />
   <keyStore id="odmDefaultTrustStore" location="/config/security/truststore.p12" password="__TRUSTSTORE_PASSWORD__" type="PKCS12" />
       


### PR DESCRIPTION
Add new parameter trustDefaultCerts in Liberty ssl element (in tlsSecurity.xml) 
https://openliberty.io/docs/latest/reference/config/ssl.html

That way the system root ca can be used to check if a certificate can be trusted when connecting to a remote server securely