### PR TITLE
error if no TLS key pair specified

### DIFF
--- a/common/config/tlsSecurity.xml
+++ b/common/config/tlsSecurity.xml
@@ -1,6 +1,6 @@
 <server>
   <sslDefault sslRef="odmDefaultSSLConfig" />
-  <ssl id="odmDefaultSSLConfig" verifyHostname="false" keyStoreRef="odmDefaultKeyStore" serverKeyAlias="odm" trustStoreRef="odmDefaultTrustStore" sslProtocol="TLSv1.2,TLSv1.3" enabledCiphers="ENABLED_CIPHERS" trustDefaultCerts="true" />
+  <ssl id="odmDefaultSSLConfig" verifyHostname="false" keyStoreRef="odmDefaultKeyStore" trustStoreRef="odmDefaultTrustStore" sslProtocol="TLSv1.2,TLSv1.3" enabledCiphers="ENABLED_CIPHERS" trustDefaultCerts="true" />
   <keyStore id="odmDefaultKeyStore" location="/config/security/keystore.p12" password="__KEYSTORE_PASSWORD__" type="PKCS12" />
   <keyStore id="odmDefaultTrustStore" location="/config/security/truststore.p12" password="__TRUSTSTORE_PASSWORD__" type="PKCS12" />
       

--- a/common/script/configureTlsSecurity.sh
+++ b/common/script/configureTlsSecurity.sh
@@ -94,6 +94,8 @@ then
         keytool -J"-Xshareclasses:none" -importkeystore -srckeystore /config/security/mycert.p12 -srcstorepass $DEFAULT_KEYSTORE_PASSWORD -srcstoretype PKCS12 -destkeystore /config/security/keystore.jks -deststoretype JKS -deststorepass $DEFAULT_KEYSTORE_PASSWORD
         rm /config/security/truststore.jks
         keytool -J"-Xshareclasses:none" -import -v -trustcacerts -alias ODM -file /config/security/volume/tls.crt -keystore /config/security/truststore.jks -storepass $DEFAULT_TRUSTSTORE_PASSWORD -storetype jks -noprompt
+
+		sed -i 's|<ssl |<ssl serverKeyAlias="odm" |' /config/tlsSecurity.xml
 fi
 # End - Configuration for the TLS security
 


### PR DESCRIPTION
Error "The odm certificate alias specified by the attribute serverKeyAlias is either not found in KeyStore /config/security/keystore.p12 or it is invalid."