### PR TITLE
HTDS page run.jsp should require authentication

### DIFF
--- a/decisionserver/decisionserverruntime/config/basicAuth.xml
+++ b/decisionserver/decisionserverruntime/config/basicAuth.xml
@@ -3,6 +3,7 @@
 		<web-resource-name>Decision Service</web-resource-name>
 		<url-pattern>/ws/*</url-pattern>
 		<url-pattern>/rest/*</url-pattern>
+		<url-pattern>/run.jsp</url-pattern>
 	</web-resource-collection>
 	<auth-constraint>
 		<role-name>resExecutors</role-name>


### PR DESCRIPTION
otherwise the page might not load completely (as seen in a setup with EntraID using ingress).

When using ingress, the request when clicking "Retrieve HTDS Description File > Test" is processed in a different pod (dsr instead of dsc).
Setting run.jsp to require the resExecutor role lets Liberty requests a token to the OIDC provider to authenticate the request as the user is not authenticated yet (in dsr).